### PR TITLE
会議室Dを追加（画像・選択・レイアウト対応）

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,14 @@
         <img src="https://www.creationline.com/tech-blog/cms_x3GWkuX/wp-content/uploads/2024/04/main4.webp" alt="会議室B">
         <span>会議室B</span>
       </div>
+      <div class="room-image" data-room="C">
+        <img src="https://www.creationline.com/tech-blog/cms_x3GWkuX/wp-content/uploads/2024/04/main2.webp" alt="会議室C">
+        <span>会議室C</span>
+      </div>
+      <div class="room-image" data-room="D">
+        <img src="https://placehold.jp/220x120.png" alt="会議室D">
+        <span>会議室D</span>
+      </div>
     </div>
     <form id="reserveForm">
       <label>
@@ -25,6 +33,8 @@
         <select id="roomSelect" name="room">
           <option value="A">会議室A</option>
           <option value="B">会議室B</option>
+          <option value="C">会議室C</option>
+          <option value="D">会議室D</option>
         </select>
       </label>
       <label>

--- a/script.js
+++ b/script.js
@@ -103,5 +103,5 @@ document.getElementById('downloadCsvBtn').addEventListener('click', function() {
   URL.revokeObjectURL(url);
 });
 
-// 初期選択
+// 初期選択をA→Dも選択可能に
 update_room_selection('A'); 

--- a/style.css
+++ b/style.css
@@ -42,11 +42,12 @@ h1 {
 .room-images {
   display: flex;
   justify-content: space-between;
-  gap: 28px;
+  gap: 20px;
   margin-bottom: 36px;
 }
 .room-image {
-  flex: 1;
+  flex: 1 1 0;
+  min-width: 0;
   text-align: center;
   border: 2.5px solid transparent;
   border-radius: 16px;
@@ -162,6 +163,16 @@ button[type="submit"]:hover, #downloadCsvBtn:hover {
   background: linear-gradient(90deg, var(--color-btn-hover) 60%, var(--color-accent) 100%);
   transform: translateY(-2px) scale(1.03);
   box-shadow: 0 4px 16px var(--color-shadow);
+}
+@media (max-width: 900px) {
+  .room-images {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .room-image {
+    min-width: 45%;
+    max-width: 48%;
+  }
 }
 @media (max-width: 700px) {
   main {


### PR DESCRIPTION
会議室Dを追加しました。
- 画像リスト・プルダウン・選択処理・CSV出力すべてでDに対応
- 仮画像（https://placehold.jp/220x120.png）を使用
- レイアウトも4部屋対応に調整
ご確認ください。