### PR TITLE
予約情報表示エリアに高さ上限とスクロールを追加（Issue #2対応）

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
       <button type="submit">予約</button>
     </form>
     <button id="downloadCsvBtn">CSVダウンロード</button>
+    <div id="reservationList" class="reservation-list"></div>
   </main>
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -47,6 +47,21 @@ generate_time_options(document.getElementById('endTime'));
 // 予約データ格納用
 let reservations = [];
 
+function render_reservation_list() {
+  const listDiv = document.getElementById('reservationList');
+  if (!listDiv) return;
+  if (reservations.length === 0) {
+    listDiv.innerHTML = '<span>予約情報はありません。</span>';
+    return;
+  }
+  let html = '<ul>';
+  reservations.forEach((r, i) => {
+    html += `<li>${i + 1}. [${r.room}] ${r.start} ～ ${r.end} / ${r.reserver}</li>`;
+  });
+  html += '</ul>';
+  listDiv.innerHTML = html;
+}
+
 // 予約フォーム送信
 const reserveForm = document.getElementById('reserveForm');
 reserveForm.addEventListener('submit', function(e) {
@@ -74,6 +89,7 @@ reserveForm.addEventListener('submit', function(e) {
   alert('予約が完了しました！');
   reserveForm.reset();
   update_room_selection('A');
+  render_reservation_list();
   // デフォルト値を再設定
   generate_time_options(document.getElementById('startTime'));
   generate_time_options(document.getElementById('endTime'));
@@ -102,6 +118,9 @@ document.getElementById('downloadCsvBtn').addEventListener('click', function() {
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 });
+
+// 初期表示
+render_reservation_list();
 
 // 初期選択をA→Dも選択可能に
 update_room_selection('A'); 

--- a/style.css
+++ b/style.css
@@ -187,4 +187,28 @@ button[type="submit"]:hover, #downloadCsvBtn:hover {
     max-width: 100vw;
     height: 100px;
   }
+}
+.reservation-list {
+  max-height: 220px;
+  overflow-y: auto;
+  background: #faf9f6;
+  border: 1.5px solid var(--color-border);
+  border-radius: 10px;
+  margin-top: 18px;
+  padding: 12px 16px;
+  box-shadow: 0 2px 8px var(--color-shadow);
+  font-size: 1rem;
+  color: var(--color-primary);
+}
+.reservation-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.reservation-list li {
+  padding: 6px 0;
+  border-bottom: 1px solid #e0dede;
+}
+.reservation-list li:last-child {
+  border-bottom: none;
 } 


### PR DESCRIPTION
予約情報表示エリアに高さ上限とスクロールを追加し、予約件数が多くなってもUIが崩れないようにしました。
- .reservation-listにmax-heightとoverflow-y: autoを追加
- 予約情報をリスト形式で表示
- 予約追加時に自動で描画

Issue: https://github.com/cl-y-arai/mtgroomreserve-demo/issues/2